### PR TITLE
Fix dead 'Releasing' wording; add message_file for dynamic announcements

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,26 @@ The success/failure split still has to come from each pipeline's `when: status:`
 conditions — Woodpecker 3.x removed `CI_PIPELINE_STATUS`, so the plugin cannot detect
 failure on its own. Only the channel choice lives in the plugin.
 
+## Dynamic messages from a file (`message_file`)
+
+Plugin `settings:` are static YAML, so a message whose content is computed at
+runtime (e.g. "which versions did this deploy actually include?") can't be
+passed via `message:`. Instead, have an earlier step write the message to a
+file in the workspace and point the plugin at it:
+
+```yaml
+  announce-deploy:
+    image: gowerstreet/slack:latest
+    settings:
+      message_file: deploy-announcement.txt
+```
+
+The file content is sent verbatim (Slack mrkdwn works, e.g. `<url|text>`
+links). If the file is **missing or blank, the step succeeds silently and
+sends nothing** — so a pipeline run that had nothing to announce (e.g. a no-op
+deploy) stays quiet without any conditional logic in the pipeline. Channel
+routing applies as above (successes go to `SLACK_WEBHOOK_NOTICE`).
+
 ## Build
 
 Build the binary with the following commands:

--- a/main.go
+++ b/main.go
@@ -227,6 +227,11 @@ func main() {
 			Usage:  "slack message. either this or the custom template must be set. ",
 			EnvVar: "PLUGIN_MESSAGE",
 		},
+		cli.StringFlag{
+			Name:   "message.file",
+			Usage:  "read the slack message from this file (written by an earlier pipeline step). If the file is missing or blank, send nothing and exit successfully — lets a step announce only when there is something to announce.",
+			EnvVar: "PLUGIN_MESSAGE_FILE",
+		},
 
 		// File send params
 		cli.StringFlag{
@@ -336,6 +341,7 @@ func run(c *cli.Context) error {
 			Mentions:       c.String("mentions"),
 			CustomTemplate: c.String("custom.template"),
 			Message:        c.String("message"),
+			MessageFile:    c.String("message.file"),
 			// File upload attributes
 			FilePath:             c.String("filepath"),
 			FileName:             c.String("filename"),

--- a/plugin.go
+++ b/plugin.go
@@ -81,6 +81,7 @@ type (
 		Mentions       string
 		CustomTemplate string
 		Message        string
+		MessageFile    string
 		// File Upload attributes
 		FilePath       string
 		FileName       string
@@ -152,7 +153,19 @@ func (p Plugin) Exec() error {
 	}
 
 	// Determine the message and fallback
-	if p.Config.Template != "" {
+	if p.Config.MessageFile != "" {
+		content, skip, err := messageFileContents(p.Config.MessageFile)
+		if err != nil {
+			return err
+		}
+		if skip {
+			// Nothing to announce (file absent or blank — e.g. a no-op deploy
+			// run that didn't produce an announcement). Succeed silently.
+			log.Printf("message file %q missing or empty; nothing to send", p.Config.MessageFile)
+			return nil
+		}
+		text = content
+	} else if p.Config.Template != "" {
 		var err error
 		text, err = templateMessage(p.Config.Template, p)
 		if err != nil {
@@ -508,6 +521,24 @@ func templateMessage(t string, plugin Plugin) (string, error) {
 	return template.RenderTrim(c, plugin)
 }
 
+// messageFileContents reads the announcement text produced by an earlier
+// pipeline step. skip=true (with no error) when the file doesn't exist or is
+// blank — the step has nothing to announce and should succeed silently.
+func messageFileContents(path string) (text string, skip bool, err error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", true, nil
+		}
+		return "", false, err
+	}
+	content := strings.TrimSpace(string(data))
+	if content == "" {
+		return "", true, nil
+	}
+	return content, false, nil
+}
+
 func message(repo Repo, build Build, config Config) string {
 	var repoLink string
     var status string
@@ -520,7 +551,14 @@ func message(repo Repo, build Build, config Config) string {
 	} else {
         branch = fmt.Sprintf("*%s*", build.Branch)
         repoLink = fmt.Sprintf("<https://github.com/%s/%s/tree/%s|%s>", repo.Owner, repo.Name, build.Branch, branch)
-        if build.Status == "Success" {
+        // "Releasing", not "deployed": a successful branch pipeline means the
+        // merge landed and (for service repos) a deployerer bump was pushed —
+        // the authoritative "live in prod" announcement is posted by
+        // deployerer's deploy pipeline after its convergence check. Note:
+        // PLUGIN_STATUS arrives lowercase, so the previous `== "Success"`
+        // comparison never matched and "Releasing" was dead code — real
+        // messages read "Success: ...". EqualFold makes it actually fire.
+        if strings.EqualFold(build.Status, "success") {
             status = "Releasing"
         } else {
             status = cases.Title(language.Und).String(build.Status)

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -141,9 +141,45 @@ func TestDefaultMessage(t *testing.T) {
     config := getTestConfig()
 
 	msg := message(repo, build, config)
-	expectedMessage := "Success: <https://github.com/octocat/hello-world/|hello-world>/<https://github.com/octocat/hello-world/tree/master|*master*> • <http://github.com/octocat/hello-world|CI Pipeline>\n`Initial commit` by octocat@github.com"
+	// PLUGIN_STATUS arrives lowercase; the case-insensitive comparison must
+	// fire the "Releasing" wording (it was dead code before).
+	expectedMessage := "Releasing: <https://github.com/octocat/hello-world/|hello-world>/<https://github.com/octocat/hello-world/tree/master|*master*> • <http://github.com/octocat/hello-world|CI Pipeline>\n`Initial commit` by octocat@github.com"
 
 	assert.Equal(t, expectedMessage, msg)
+}
+
+func TestDefaultMessageFailure(t *testing.T) {
+	repo := getTestRepo()
+	build := getTestBuild()
+	build.Status = "failure"
+    config := getTestConfig()
+
+	msg := message(repo, build, config)
+	expectedMessage := "Failure: <https://github.com/octocat/hello-world/|hello-world>/<https://github.com/octocat/hello-world/tree/master|*master*> • <http://github.com/octocat/hello-world|CI Pipeline>\n`Initial commit` by octocat@github.com"
+
+	assert.Equal(t, expectedMessage, msg)
+}
+
+func TestMessageFileContents(t *testing.T) {
+	// Missing file: skip silently.
+	_, skip, err := messageFileContents("/nonexistent/announce.txt")
+	assert.NilError(t, err)
+	assert.Equal(t, true, skip)
+
+	// Blank file: skip silently.
+	blank := t.TempDir() + "/blank.txt"
+	assert.NilError(t, os.WriteFile(blank, []byte("  \n\t\n"), 0o644))
+	_, skip, err = messageFileContents(blank)
+	assert.NilError(t, err)
+	assert.Equal(t, true, skip)
+
+	// Content: returned trimmed, no skip.
+	msgFile := t.TempDir() + "/announce.txt"
+	assert.NilError(t, os.WriteFile(msgFile, []byte("Deployment Successful • <http://ci|CI Pipeline>\n• line\n"), 0o644))
+	text, skip, err := messageFileContents(msgFile)
+	assert.NilError(t, err)
+	assert.Equal(t, false, skip)
+	assert.Equal(t, "Deployment Successful • <http://ci|CI Pipeline>\n• line", text)
 }
 
 


### PR DESCRIPTION
Two changes, motivated by moving deployerer's post-deploy announcement out of a raw `curl` and into this plugin (so it routes to **#notice** via the existing success→`SLACK_WEBHOOK_NOTICE` logic instead of the alerts-bound webhook secret).

## 1. Fix: the success wording was dead code
`PLUGIN_STATUS` arrives lowercase, so `build.Status == "Success"` never matched — **"Releasing" has never actually displayed**; real messages read `Success: …`. The comparison is now case-insensitive, so successful branch pushes say `Releasing: repo/master • …` as originally intended.

## 2. New `message_file` setting
Plugin `settings:` are static, so runtime-computed content (deployerer's "what did this deploy include") couldn't go through `message:`. Now:

```yaml
  announce-deploy:
    image: gowerstreet/slack:latest
    settings:
      message_file: deploy-announcement.txt
```

- File content sent verbatim (Slack mrkdwn links work).
- **Missing/blank file → send nothing, exit 0** — a no-op deploy run stays silent with zero pipeline conditionals.
- Channel routing unchanged: success → `SLACK_WEBHOOK_NOTICE` (#notice), default-branch failure → alerts.

## Follow-up (deployerer, after this merges + publishes)
`deploy.sh` writes `deploy-announcement.txt` on real state transitions (format: `Deployment Successful • <pipeline|CI Pipeline>` + one linked bullet per included commit), and a new `announce-deploy` plugin step replaces the curl.

Tests: case-fix expectations, failure case, and `messageFileContents` (missing/blank/content); `go test ./...` green. README documents `message_file`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)