### PR TITLE
Fall back through author fields; omit byline when empty

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -571,14 +571,29 @@ func message(repo Repo, build Build, config Config) string {
 		description = fmt.Sprintf("%s • ", config.Description)
 	}
 
-    return fmt.Sprintf("%s: %s/%s • %s<%s|CI Pipeline>\n`%s` by %s",
+	// Woodpecker doesn't populate CI_COMMIT_AUTHOR_EMAIL on every event, which
+	// used to leave messages ending in a dangling "by ". Fall back through the
+	// author fields and drop the byline entirely when none is set.
+	author := build.Author.Email
+	if author == "" {
+		author = build.Author.Username
+	}
+	if author == "" {
+		author = build.Author.Name
+	}
+	byline := ""
+	if author != "" {
+		byline = fmt.Sprintf(" by %s", author)
+	}
+
+    return fmt.Sprintf("%s: %s/%s • %s<%s|CI Pipeline>\n`%s`%s",
         status,
         repoName,
         repoLink,
         description,
 		build.Link,
         build.Message.Title,
-		build.Author.Email,
+		byline,
 	)
 }
 

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -160,6 +160,28 @@ func TestDefaultMessageFailure(t *testing.T) {
 	assert.Equal(t, expectedMessage, msg)
 }
 
+func TestDefaultMessageAuthorFallsBackToUsername(t *testing.T) {
+	// Woodpecker doesn't set CI_COMMIT_AUTHOR_EMAIL on every event; the byline
+	// must fall back to the username rather than render a dangling "by ".
+	repo := getTestRepo()
+	build := getTestBuild()
+	build.Author.Email = ""
+    config := getTestConfig()
+
+	msg := message(repo, build, config)
+	assert.Equal(t, true, strings.HasSuffix(msg, "`Initial commit` by octocat"))
+}
+
+func TestDefaultMessageNoAuthorOmitsByline(t *testing.T) {
+	repo := getTestRepo()
+	build := getTestBuild()
+	build.Author = Author{}
+    config := getTestConfig()
+
+	msg := message(repo, build, config)
+	assert.Equal(t, true, strings.HasSuffix(msg, "`Initial commit`"))
+}
+
 func TestMessageFileContents(t *testing.T) {
 	// Missing file: skip silently.
 	_, skip, err := messageFileContents("/nonexistent/announce.txt")


### PR DESCRIPTION
Observed live on a forecast CI failure:

```
Failure: forecast/remove-ermine-metadata-api • forecast.gower.st • CI Pipeline
Read /api/v3/metadata from forecast_app.metadata instead of Ermine by
```

— dangling `by` because Woodpecker didn't set `CI_COMMIT_AUTHOR_EMAIL` for that event while the message renders `by %s` unconditionally.

Byline now falls back **Email → Username → Name** (`CI_COMMIT_AUTHOR` is reliably set, so in practice the username appears), and is **omitted entirely** when all are empty. Existing messages with an email are byte-identical.

Tests: fallback-to-username + omit-when-empty; `go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)